### PR TITLE
feat: add "guid" to device reports

### DIFF
--- a/lib/audioDevices.cc
+++ b/lib/audioDevices.cc
@@ -9,6 +9,16 @@
 #include <atlstr.h>
 #endif
 
+// Lange: Copied from https://chromium.googlesource.com/external/webrtc/+/branch-heads/43/talk/media/devices/win32devicemanager.cc#40
+// There's some conflict I don't understand,
+// the hack is to just define this one symbol manually.
+// See: https://code.google.com/p/webrtc/issues/detail?id=3996
+EXTERN_C const PROPERTYKEY PKEY_AudioEndpoint_GUID = { {
+  0x1da5d803, 0xd492, 0x4edd, {
+    0x8c, 0x23, 0xe0, 0xc0, 0xff, 0xee, 0x7f, 0x0e
+  } }, 4
+};
+
 using namespace v8;
 
 #ifdef _WIN32
@@ -52,6 +62,13 @@ boolean ExtractDataFromCollection(
     hr = pEndpoint->OpenPropertyStore(STGM_READ, &pProps);
     if (FAILED(hr))
       return false;
+
+    PROPVARIANT deviceGuid;
+    PropVariantInit(&deviceGuid);
+    hr = pProps->GetValue(PKEY_AudioEndpoint_GUID, &deviceGuid);
+    if (FAILED(hr))
+      return false;
+    obj->Set(String::NewFromUtf8(isolate, "guid"), String::NewFromUtf8(isolate, CW2A(deviceGuid.pwszVal)));
 
     PROPVARIANT deviceName;
     PropVariantInit(&deviceName);


### PR DESCRIPTION
This is useful for things like enumerating the available audio devices, presenting a list for a user to choose from, then taking the chosen device and having some other program use it, via the guid.

For example, VLC needs the device guid when selecting an audio output device.